### PR TITLE
Fix 'getJointeffort' function name

### DIFF
--- a/include/robotis_manipulator/robotis_manipulator_common.h
+++ b/include/robotis_manipulator/robotis_manipulator_common.h
@@ -201,7 +201,7 @@ public:
   void setComponentDynamicPoseToWorld(Name name, Dynamicpose dynamic_pose);
   void setJointValue(Name name, double joint_value);
   void setJointVelocity(Name name, double joint_velocity);
-  void setJointeffort(Name name, double joint_effort);
+  void setJointEffort(Name name, double joint_effort);
   void setJointValue(Name name, WayPoint joint_value);
 //  void setJointValueFromId(int8_t joint_id, WayPoint joint_value);
   void setAllActiveJointValue(std::vector<double> joint_value_vector);
@@ -246,7 +246,7 @@ public:
   Eigen::Vector3d getJointAxis(Name name);
   double getJointValue(Name name);
   double getJointVelocity(Name name);
-  double getJointeffort(Name name);
+  double getJointEffort(Name name);
 //  Actuator getJointActuatorValue(Name name);
   int8_t getToolId(Name name);
   double getToolCoefficient(Name name);

--- a/src/robotis_manipulator.cpp
+++ b/src/robotis_manipulator.cpp
@@ -461,7 +461,7 @@ WayPoint RobotisManipulator::receiveJointActuatorValue(Name joint_component_name
 
     result.at(0).value = result.at(0).value * manipulator_.getJointCoefficient(joint_component_name);
     result.at(0).velocity = result.at(0).velocity * manipulator_.getJointCoefficient(joint_component_name);
-    result.at(0).effort = result.at(0).velocity * manipulator_.getJointCoefficient(joint_component_name);
+    result.at(0).effort = result.at(0).effort * manipulator_.getJointCoefficient(joint_component_name);
 
     manipulator_.setJointValue(joint_component_name, result.at(0));
     return result.at(0);

--- a/src/robotis_manipulator_common.cpp
+++ b/src/robotis_manipulator_common.cpp
@@ -251,7 +251,7 @@ void Manipulator::setJointVelocity(Name name, double joint_velocity)
   }
 }
 
-void Manipulator::setJointeffort(Name name, double joint_effort)
+void Manipulator::setJointEffort(Name name, double joint_effort)
 {
   if (component_.at(name).tool.id > 0)
   {
@@ -633,7 +633,7 @@ double Manipulator::getJointVelocity(Name name)
   return component_.at(name).joint.velocity;
 }
 
-double Manipulator::getJointeffort(Name name)
+double Manipulator::getJointEffort(Name name)
 {
   return component_.at(name).joint.effort;
 }

--- a/src/robotis_manipulator_trajectory_generator.cpp
+++ b/src/robotis_manipulator_trajectory_generator.cpp
@@ -348,7 +348,7 @@ void Trajectory::setPresentJointWayPoint(std::vector<WayPoint> joint_value_vecto
     {
       manipulator_.setJointValue(it->first, joint_value_vector.at(index).value);
       manipulator_.setJointVelocity(it->first, joint_value_vector.at(index).velocity);
-      manipulator_.setJointeffort(it->first, joint_value_vector.at(index).effort);
+      manipulator_.setJointEffort(it->first, joint_value_vector.at(index).effort);
     }
     index++;
   }
@@ -397,7 +397,7 @@ std::vector<WayPoint> Trajectory::getPresentJointWayPoint()
       // Active
       result.value = manipulator_.getJointValue(it->first);
       result.velocity = manipulator_.getJointVelocity(it->first);
-      result.effort = manipulator_.getJointeffort(it->first);
+      result.effort = manipulator_.getJointEffort(it->first);
 
       result_vector.push_back(result);
     }


### PR DESCRIPTION
Changing 'getJoint**e**ffort' to 'getJoint**E**ffort', accordingly to the surrounding functions.

Please let me know if there is a specific reason to leave `effort` on low case.