### PR TITLE
Change to inclusive joint limits

### DIFF
--- a/src/robotis_manipulator/robotis_manipulator_common.cpp
+++ b/src/robotis_manipulator/robotis_manipulator_common.cpp
@@ -738,9 +738,9 @@ std::vector<Name> Manipulator::getAllActiveJointComponentName()
 
 bool Manipulator::checkLimit(Name component_name, double value)
 {
-  if(component_.at(component_name).actuator_constant.limit.maximum <= value)
+  if(component_.at(component_name).actuator_constant.limit.maximum < value)
     return false;
-  else if(component_.at(component_name).actuator_constant.limit.minimum >= value)
+  else if(component_.at(component_name).actuator_constant.limit.minimum > value)
     return false;
   else
     return true;


### PR DESCRIPTION
Using inclusive limits. This avoids limits errors when e.g. clicking on `Gripper open` on `open_manipulator_control_gui`.

```
[ERROR] [checkLimit] Goal value exceeded limit. The moving stop.
```

As always, am open to discussions about if this is the right thing to do or not.