### PR TITLE
Update robotis_manipulator_log.h

### DIFF
--- a/include/robotis_manipulator/robotis_manipulator_log.h
+++ b/include/robotis_manipulator/robotis_manipulator_log.h
@@ -21,6 +21,7 @@
 
 #include <unistd.h>
 #include <vector>
+#include <cstdint>
 
 #if defined(__OPENCR__)
   #include <Eigen.h>


### PR DESCRIPTION
Fix error using `uint8_t` type on Ubuntu 24.04.
![image](https://github.com/user-attachments/assets/ce0d4f72-7459-41b0-88b7-7042cfccf3b3)
